### PR TITLE
GM-1: set private data to nil

### DIFF
--- a/gomilter.go
+++ b/gomilter.go
@@ -343,6 +343,19 @@ func Go_xxfi_close(ctx *C.SMFICTX) C.sfsistat {
 	if milter.GetDebug() {
 		logger.Printf("Close callback returned: %d\n", code)
 	}
+
+	// Verify if the private data from ctx is already NULL 
+	// Call libmilter smfi_getpriv to get a pointer to our data
+	CArray := (*byte)(C.smfi_getpriv(ctx))
+	pointerToData := unsafe.Pointer(CArray)
+	if pointerToData != nil {
+		lenStart := uintptr(unsafe.Pointer(CArray))
+		// Free the data malloc'ed by C
+		C.free(unsafe.Pointer(lenStart))
+		C.smfi_setpriv(ctx, nil)
+	}
+	
+
 	return C.sfsistat(code)
 }
 


### PR DESCRIPTION
get pointer to private data and check if it is not nil, if that is the case set to nil, in order to avoid warning on sendmail engine.c mi_clr_ctx(ctx) function